### PR TITLE
Add remove variable to watchwindow context menu

### DIFF
--- a/src/views/treeitemview.py
+++ b/src/views/treeitemview.py
@@ -38,21 +38,21 @@ class TreeItemView(QTreeView):
         self.controller = None
         self.header().setResizeMode(QHeaderView.ResizeToContents)
         self.setDragEnabled(True)
-        self.context_menu = QMenu(self)
 
     def prepareContextMenu(self):
+        context_menu = QMenu(self)
         wrapper = self.selectionModel().currentIndex().internalPointer()
         if isinstance(wrapper, TreeStdVarWrapper):
-            filters.add_actions_for_all_filters(self.context_menu.addMenu(
+            filters.add_actions_for_all_filters(context_menu.addMenu(
                 "Set Filter for %s..." % wrapper.exp),  wrapper)
+        return context_menu
 
 
     def contextMenuEvent(self, event):
         QTreeView.contextMenuEvent(self, event)
-        if not event.isAccepted():
-            wrapper = self.selectionModel().currentIndex().internalPointer()
-            if isinstance(wrapper, TreeStdVarWrapper):
-                self.prepareContextMenu()
-                self.contextMenuOpen.emit(True)
-                self.context_menu.exec_(event.globalPos())
-                self.contextMenuOpen.emit(False)
+        wrapper = self.selectionModel().currentIndex().internalPointer()
+        if not event.isAccepted() and wrapper is not None:
+            menu = self.prepareContextMenu()
+            self.contextMenuOpen.emit(True)
+            menu.exec_(event.globalPos())
+            self.contextMenuOpen.emit(False)

--- a/src/views/watchview.py
+++ b/src/views/watchview.py
@@ -52,6 +52,8 @@ class WatchView(TreeItemView):
         self.controller.removeSelected(self.selectionModel().currentIndex())
 
     def prepareContextMenu(self):
-        TreeItemView.prepareContextMenu(self)
-        self.context_menu.addAction("Remove variable").triggered.connect(
-                self.removeVariable)
+        menu = TreeItemView.prepareContextMenu(self)
+        if self.selectionModel().currentIndex().parent().internalPointer() is None:
+            menu.addAction("Remove variable").triggered.connect(
+                    self.removeVariable)
+        return menu


### PR DESCRIPTION
This pull request adds the possibility to extend the context menu of the TreeItemView through overwriting the inherit method and still calling the function of the superclass.

Doing it this way makes it very easy to add more action and it is also very flexible. 

The way the context menu works in the datagraph is too specific to generalise it. But I could try to unify it by writing something like helper/context_menu.py.
