### PR TITLE
Remove unused functions from wrappers

### DIFF
--- a/src/variables/arrayvariablewrapper.py
+++ b/src/variables/arrayvariablewrapper.py
@@ -36,8 +36,3 @@ class ArrayVariableWrapper(VariableWrapper):
         @param variable    variables.variable.Variable, the variable to wrap
         """
         VariableWrapper.__init__(self, variable)
-
-    def getChildren(self):
-        """ Returns a List with all Members of the struct.
-        @return    List of Variables, Members of the struct. """
-        return self.variable.getChildren()

--- a/src/variables/ptrvariablewrapper.py
+++ b/src/variables/ptrvariablewrapper.py
@@ -36,9 +36,3 @@ class PtrVariableWrapper(VariableWrapper):
         @param variable    variables.variable.Variable, the variable to wrap
         """
         VariableWrapper.__init__(self, variable)
-
-    def dereference(self):
-        """ Dereferences the Variable, if possible.
-        @return    dereferenced Variable
-        """
-        return self.variable.dereference()

--- a/src/variables/structvariablewrapper.py
+++ b/src/variables/structvariablewrapper.py
@@ -37,7 +37,3 @@ class StructVariableWrapper(VariableWrapper):
         """
         VariableWrapper.__init__(self, variable)
 
-    def getChildren(self):
-        """ Returns a List with all Members of the struct.
-        @return    List of Variables, Members of the struct. """
-        return self.variable.getChildren()


### PR DESCRIPTION
The getChildren and derefernce functions are never callled. Also the member
self.variable was renamed some time ago and would have led to crashes but
because it was never called we did not notice.
