### PR TITLE
Add checks for broken QSettings

### DIFF
--- a/src/helpers/recentfilehandler.py
+++ b/src/helpers/recentfilehandler.py
@@ -111,7 +111,7 @@ class RecentFileHandler():
         """Load recently used files from self.recentfiles to the menu. """
         for action_index in range(self.nrRecentFiles):
             filename = self.recentFiles[action_index]
-            if exists(filename):
+            if filename is not None and exists(filename):
                 self.actions[action_index].setText(filename)
                 self.actions[action_index].setVisible(True)
             else:

--- a/src/views/mainwindow.py
+++ b/src/views/mainwindow.py
@@ -268,8 +268,10 @@ class MainWindow(QMainWindow):
             self.pluginloader.savePluginInfo()
 
     def readSettings(self):
-        self.restoreGeometry(self.settings.value("geometry"))
-        self.restoreState(self.settings.value("windowState"))
+        if self.settings.value("geometry") is not None:
+            self.restoreGeometry(self.settings.value("geometry"))
+        if self.settings.value("windowState") is not None:
+            self.restoreState(self.settings.value("windowState"))
         self.dockToolBarManager.restoreState(self.settings)
 
     def setReverseDebugButtonsState(self, check):


### PR DESCRIPTION
Ricodebug crashed for me on startup using
- Linux 3.19.2
- Python 3.4.3
- PyQt4 4.11.3.

I could quick-fix it at jakobwinkler/ricodebug@92508c07700af55d0ea4caa20780ca11ec99262a but I'm unsure about this. If I understood the docs correctly, QSettings.value should never return None (logs below). Also I don't know if I followed any coding conventions because I'm not very familiar with python.

```
Traceback (most recent call last):
  File "ricodebug.py", line 79, in <module>
    main()
  File "ricodebug.py", line 66, in main
    window = MainWindow()
  File "/home/erpfi/tmp/ricodebug/src/views/mainwindow.py", line 67, in __init__
    self.recentFileHandler = RecentFileHandler(self, self.ui.menuRecentlyUsedFiles, self.do)
  File "/home/erpfi/tmp/ricodebug/src/helpers/recentfilehandler.py", line 65, in __init__
    self.__loadRecentFiles()
  File "/home/erpfi/tmp/ricodebug/src/helpers/recentfilehandler.py", line 114, in __loadRecentFiles
    if exists(filename):
  File "/usr/lib/python3.4/genericpath.py", line 19, in exists
    os.stat(path)
TypeError: stat: can't specify None for path argument
QObject::startTimer: QTimer can only be used with threads started with QThread
QObject::startTimer: QTimer can only be used with threads started with QThread
Segmentation fault (core dumped)
```

After fixing this I got:

```
Traceback (most recent call last):
  File "ricodebug.py", line 79, in <module>
    main()
  File "ricodebug.py", line 66, in main
    window = MainWindow()
  File "/home/erpfi/tmp/ricodebug/src/views/mainwindow.py", line 92, in __init__
    self.readSettings()
  File "/home/erpfi/tmp/ricodebug/src/views/mainwindow.py", line 271, in readSettings
    self.restoreGeometry(self.settings.value("geometry"))
TypeError: QWidget.restoreGeometry(QByteArray): argument 1 has unexpected type 'NoneType'
QObject::startTimer: QTimer can only be used with threads started with QThread
QObject::startTimer: QTimer can only be used with threads started with QThread
QObject::startTimer: QTimer can only be used with threads started with QThread
QObject::startTimer: QTimer can only be used with threads started with QThread
QObject::startTimer: QTimer can only be used with threads started with QThread
Segmentation fault (core dumped)
```
